### PR TITLE
Botón de like local

### DIFF
--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -153,7 +153,7 @@ class FeedItem {
   final String? imageUrl;
   final User user;
   final int commentsCount;
-  final int likesCount;
+  int likesCount;
   final int retweetsCount;
   final DateTime postDate;
 

--- a/lib/visual/Screens/feed.dart
+++ b/lib/visual/Screens/feed.dart
@@ -241,7 +241,14 @@ class _ActionsRow extends StatefulWidget {
 }
 
 class _ActionsRowState extends State<_ActionsRow> {
-  bool _isLiked = false;
+  bool isLiked = false;
+
+  void toggleLike(){
+    setState(() {
+      isLiked? widget.item.likesCount--:widget.item.likesCount++;
+      isLiked = !isLiked;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -267,14 +274,15 @@ class _ActionsRowState extends State<_ActionsRow> {
             label: Text(
                 widget.item.retweetsCount == 0 ? '' : widget.item.retweetsCount.toString()),
           ),
-          likeButton(
-            isLiked: _isLiked,
-            onTap: () {
-              setState((){
-                _isLiked = !_isLiked;
-              });
-            },
+
+          TextButton.icon(
+              onPressed: toggleLike,
+              icon: Icon(
+                isLiked? Icons.favorite: Icons.favorite_border_sharp,
+                color: isLiked? Colors.red : Colors.grey),
+              label: Text(widget.item.likesCount.toString())
           ),
+
           IconButton(
             icon: const Icon(CupertinoIcons.share_up),
             onPressed: () {},
@@ -286,23 +294,6 @@ class _ActionsRowState extends State<_ActionsRow> {
 }
 
 //----------------------Importacion de la lista de posts----------------------
-
-class likeButton extends StatelessWidget {
-  bool isLiked;
-  void Function()? onTap;
-
-  likeButton({super.key, required this.isLiked, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Icon(
-        isLiked? Icons.favorite: Icons.favorite_border,
-        color: isLiked? Colors.red : Colors.grey),
-    );
-  }
-}
 
 class MoreBottomSheet extends StatefulWidget {
   const MoreBottomSheet({super.key});

--- a/lib/visual/Screens/feed.dart
+++ b/lib/visual/Screens/feed.dart
@@ -4,7 +4,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class NewsFeedPage1 extends StatefulWidget {
-  const NewsFeedPage1({super.key});
+  const NewsFeedPage1({
+    super.key,
+  });
 
   @override
   State<NewsFeedPage1> createState() => _NewsFeedPage1State();
@@ -228,10 +230,19 @@ class _AvatarImage extends StatelessWidget {
   }
 }
 
-class _ActionsRow extends StatelessWidget {
+// ------------------------Panel de iconos------------------------------------//
+
+class _ActionsRow extends StatefulWidget {
   final FeedItem item;
   const _ActionsRow({required this.item});
-// ------------------------Panel de iconos------------------------------------//
+
+  @override
+  State<_ActionsRow> createState() => _ActionsRowState();
+}
+
+class _ActionsRowState extends State<_ActionsRow> {
+  bool _isLiked = false;
+
   @override
   Widget build(BuildContext context) {
     return Theme(
@@ -248,18 +259,21 @@ class _ActionsRow extends StatelessWidget {
             onPressed: () {},
             icon: const Icon(Icons.mode_comment_outlined),
             label: Text(
-                item.commentsCount == 0 ? '' : item.commentsCount.toString()),
+                widget.item.commentsCount == 0 ? '' : widget.item.commentsCount.toString()),
           ),
           TextButton.icon(
             onPressed: () {},
             icon: const Icon(Icons.repeat_rounded),
             label: Text(
-                item.retweetsCount == 0 ? '' : item.retweetsCount.toString()),
+                widget.item.retweetsCount == 0 ? '' : widget.item.retweetsCount.toString()),
           ),
-          TextButton.icon(
-            onPressed: () {},
-            icon: const Icon(Icons.favorite_border),
-            label: Text(item.likesCount == 0 ? '' : item.likesCount.toString()),
+          likeButton(
+            isLiked: _isLiked,
+            onTap: () {
+              setState((){
+                _isLiked = !_isLiked;
+              });
+            },
           ),
           IconButton(
             icon: const Icon(CupertinoIcons.share_up),
@@ -272,6 +286,23 @@ class _ActionsRow extends StatelessWidget {
 }
 
 //----------------------Importacion de la lista de posts----------------------
+
+class likeButton extends StatelessWidget {
+  bool isLiked;
+  void Function()? onTap;
+
+  likeButton({super.key, required this.isLiked, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Icon(
+        isLiked? Icons.favorite: Icons.favorite_border,
+        color: isLiked? Colors.red : Colors.grey),
+    );
+  }
+}
 
 class MoreBottomSheet extends StatefulWidget {
   const MoreBottomSheet({super.key});


### PR DESCRIPTION
Funciona el botón para dar y quitar like y aumenta el contador localmente, faltaría la actualización de la base de datos pero entonces es necesario crear un collection para los likes de usuarios. 

Pd: Tuve que cambiar el _ActionsRow a stateful widget y el likes count quitarlo como final